### PR TITLE
Infinite tape

### DIFF
--- a/css/screen.css
+++ b/css/screen.css
@@ -19,10 +19,15 @@ section.machine {
         height: 32px;
     }
 
+        ul.tape .cell-index {
+            font-size: 0.5em;
+        }
+
         ul.tape li {
             list-style-type: none;
             border: 1px solid #aeaeae;
             float: left;
+            margin-top: -19px;
             width: 30px;
             height: 23px;
             text-align: center;

--- a/index.html
+++ b/index.html
@@ -112,8 +112,14 @@
 
     <script type="text/javascript">
         $(function () {
-            var cells = _(27).times($.noop);
-            var tape = new Tape(cells);
+            var cells = new Cells(_.range(27).map(function (index) {
+                return { index: index };
+            }));
+            var tape = new Tape({
+                cells: cells,
+                windowStart: 0,
+                windowSize: cells.length
+            });
             var pointer = new Pointer();
             new InterpreterView({
                 editor: $("#source"),

--- a/js/interpreter.js
+++ b/js/interpreter.js
@@ -41,12 +41,14 @@ var Interpreter = function (source, tape, pointer,
             return this.next();
         }
         var index = pointer.get("index");
-        if (index < 0 || index >= tape.models.length) {
+        var firstIndex = tape.get("cells").first().get("index");
+        var lastIndex = tape.get("cells").last().get("index");
+        if (index < firstIndex || lastIndex < index) {
             throw error("Memory error: " + index);
         }
         instruction(action);
         var token = source[action];
-        var cell = tape.models[index];
+        var cell = tape.get("cells").at(index - firstIndex);
         switch (token) {
         case "<":
             pointer.left();

--- a/js/models.js
+++ b/js/models.js
@@ -6,6 +6,9 @@ var Cell = Backbone.Model.extend({
     defaults: {
         value: 0
     },
+    initialize: function (options) {
+        this.set("index", options.index);
+    },
     inc: function () {
         if (this.get("value") == 255) {
             this.set("value", 0);
@@ -28,8 +31,14 @@ var Cell = Backbone.Model.extend({
     }
 });
 
-var Tape = Backbone.Collection.extend({
+var Cells = Backbone.Collection.extend({
     model: Cell
+});
+
+var Tape = Backbone.Model.extend({
+    tapeIndex: function (cellIndex) {
+        return cellIndex - this.get("cells").first().get("index");
+    }
 });
 
 var Pointer = Backbone.Model.extend({

--- a/js/views.js
+++ b/js/views.js
@@ -4,20 +4,28 @@ var CellView = Backbone.View.extend({
         this.model.on('change', this.render, this);
     },
     render: function () {
-        this.$el.html(this.model.get("value"));
+        this.$el.html(CellView.template({
+            index: this.model.get("index"),
+            value: this.model.get("value")
+        }));
         return this;
     }
+}, {
+    template: _.template("<span class=cell-index><%= index %></span>" +
+                         "<br><%= value %>"),
 });
 
 var PointerView = Backbone.View.extend({
     el: "div.pointer",
     initialize: function (options) {
-        this.model.on("change", this.render, this);
+        this.model.on("move", this.render, this);
         this.interpreter = options.interpreter;
+        this.tape = options.tape;
     },
     render: function () {
+        var offset = this.model.get("index") - this.tape.get("windowStart");
         this.$el.animate({
-            "margin-left": this.model.get("index") * this.$el.width()
+            "margin-left": offset * this.$el.width()
         }, 30);
         return this;
     }
@@ -28,17 +36,77 @@ var TapeView = Backbone.View.extend({
     initialize: function (options) {
         this.pointer = options.pointer;
         this.interpreter = options.interpreter;
+        this.pointer.on("change", this.handlePointerMove, this);
+    },
+    handlePointerMove: function () {
+        var index = this.pointer.get("index");
+
+        if (index < this.model.get("cells").first().get("index")) {
+            this.model.get("cells").unshift({ index: index });
+        } else if (this.model.get("cells").last().get("index") < index) {
+            this.model.get("cells").push({ index: index });
+        }
+
+        var windowStart = this.model.get("windowStart");
+        var windowEnd = windowStart + this.model.get("windowSize") - 1;
+
+        if (index < windowStart) {
+            while (index != windowStart--) {
+                this.moveWindowLeft();
+            }
+        } else if (windowEnd < index) {
+            while (index != windowEnd++) {
+                this.moveWindowRight();
+            }
+        }
+
+        this.pointer.trigger("move");
+    },
+    moveWindowLeft: function () {
+        var windowStart = this.model.get("windowStart") - 1;
+        this.model.set("windowStart", windowStart);
+
+        _(this.cellViews).last().remove();
+        this.cellViews.pop();
+        var cell = this.model.get("cells").at(this.model.tapeIndex(windowStart));
+        var cellView = new CellView({
+            model: cell
+        }, this);
+        this.cellViews.unshift(cellView);
+        this.$el.prepend(cellView.render().el);
+    },
+    moveWindowRight: function () {
+        var windowStart = this.model.get("windowStart");
+        var windowEnd = windowStart + this.model.get("windowSize");
+        this.model.set("windowStart", ++windowStart);
+
+        _(this.cellViews).first().remove();
+        this.cellViews.shift();
+        var cell = this.model.get("cells").at(this.model.tapeIndex(windowEnd));
+        var cellView = new CellView({
+            model: cell
+        }, this);
+        this.cellViews.push(cellView);
+        this.$el.append(cellView.render().el);
     },
     render: function () {
-        _.forEach(this.model.models, function (model) {
-            this.$el.append((new CellView({
-                model: model
-            })).render().el);
+        var windowStart = this.model.get("windowStart");
+        var windowEnd = windowStart + this.model.get("windowSize");
+        var cells = this.model.get("cells").slice(this.model.tapeIndex(windowStart),
+                                                  this.model.tapeIndex(windowEnd));
+
+        this.cellViews = _.map(cells, function (cell) {
+            var cellView = new CellView({
+                model: cell
+            });
+            this.$el.append(cellView.render().el);
+            return cellView;
         }, this);
 
         new PointerView({
             model: this.pointer,
-            interpreter: this.interpreter
+            interpreter: this.interpreter,
+            tape: this.model
         }).render();
 
         return this;
@@ -167,8 +235,8 @@ var InterpreterView = Backbone.View.extend({
     },
     reset: function () {
         this.pointer.set("index", 0);
-        _(this.tape.models).forEach(function (model) {
-            model.set("value", 0);
+        this.tape.get("cells").forEach(function (cell) {
+            cell.set("value", 0);
         }, this);
     },
     stop: function () {


### PR DESCRIPTION
This patch makes the tape grow from both ends when necessary which allows for programs that use more than 27 cells of memory.

It adds the concept of a window to designate the visible portion of the tape. The window starts at `tape.get("windowStart")` and lasts for `tape.get("windowSize")` cells. `windowStart` is an absolute cell index (i.e. it can be negative).

For clarity cells render to the markup that contains cell indices as well as values.

Close #18.