### PR TITLE
Add option to input hex data

### DIFF
--- a/css/screen.css
+++ b/css/screen.css
@@ -118,6 +118,10 @@ section.machine {
             outline:none;
         }
 
+        section.editor #input:invalid {
+            border: solid 2px red;
+        }
+
         section.editor #delay-box {
             float: right;
             margin-right: 25px;

--- a/css/screen.css
+++ b/css/screen.css
@@ -162,6 +162,21 @@ section.machine {
           
         }
 
+        section.editor #hex-io-box {
+            float: right;
+            margin-right: 25px;
+            text-align:center;
+        }
+
+        section.editor #hex-io-box label {
+            display: block;
+            color: gray;
+        }
+
+        section.editor #hex-io-box input {
+          
+        }
+
         section.editor span.caret {
             border-radius: 4px;
             background-color: #fff;

--- a/index.html
+++ b/index.html
@@ -42,6 +42,10 @@
                     <label for="exclaim">!</label>
                     <input id="exclaim" type="checkbox"/>
                 </div>
+                <div id="hex-io-box">
+                    <label for="hex-io">Hex</label>
+                    <input id="hex-io" type="checkbox"/>
+                </div>
                 <div id="input-box">
                     <label>Waiting for input</label>
                     <input type="text" id="input" maxlength="1"/>

--- a/index.html
+++ b/index.html
@@ -4,6 +4,7 @@
     <title>Brainfuck Visualizer</title>
     <link rel="stylesheet" href="css/screen.css" />
     <script type="text/javascript" src="js/lib/jquery-1.9.1.js"></script>
+    <script type="text/javascript" src="js/lib/jquery-validity-selectors.js"></script>
     <script type="text/javascript" src="js/lib/underscore-min.js"></script>
     <script type="text/javascript" src="js/lib/backbone-min.js"></script>
     <script type="text/javascript" src="js/interpreter.js"></script>

--- a/index.html
+++ b/index.html
@@ -45,7 +45,7 @@
                 </div>
                 <div id="hex-io-box">
                     <label for="hex-io">Hex</label>
-                    <input id="hex-io" type="checkbox"/>
+                    <input id="hex-io" title="Allows to input hex values instead of plaintext characters" type="checkbox"/>
                 </div>
                 <div id="input-box">
                     <label>Waiting for input</label>

--- a/js/lib/jquery-validity-selectors.js
+++ b/js/lib/jquery-validity-selectors.js
@@ -1,0 +1,13 @@
+// See https://stackoverflow.com/questions/15820780/jquery-support-invalid-selector/48211642
+
+jQuery.extend(jQuery.expr[':'], {
+    invalid : function(elem, index, match){
+        return elem.validity !== undefined && elem.validity.valid === false;
+    },
+
+    valid : function(elem, index, match){
+        return elem.validity !== undefined && elem.validity.valid === true;
+    }
+
+
+});

--- a/js/models.js
+++ b/js/models.js
@@ -17,7 +17,10 @@ var Cell = Backbone.Model.extend({
         this.set("value", val);
     },
     put: function (c) {
-        this.set("value", c.charCodeAt(0));
+        var isHex = $('#hex-io').is(':checked');
+
+        var value = isHex ? parseInt(c, 16) : c.charCodeAt(0);
+        this.set("value", value);
     },
     char: function () {
         return String.fromCharCode(this.get("value"))

--- a/js/views.js
+++ b/js/views.js
@@ -61,6 +61,7 @@ var InterpreterView = Backbone.View.extend({
         "click #pause": "pause",
         "click #continue": "loop",
         "click #stop": "stop",
+        "change #hex-io": "updateInputPattern",
         "change #input": "receiveInput",
         "change #delay": "changeDelay",
         "input #source": "setShareURL",
@@ -131,10 +132,12 @@ var InterpreterView = Backbone.View.extend({
         this.inputTarget = cell;
     },
     receiveInput: function () {
-        this.inputTarget.put(this.input.val());
-        this.input.parent().hide();
-        this.input.val("");
-        this.loop();
+        if (this.input.is(":valid")) {
+            this.inputTarget.put(this.input.val());
+            this.input.parent().hide();
+            this.input.val("");
+            this.loop();
+        }
     },
     removeCaret: function () {
         this.editor
@@ -199,6 +202,14 @@ var InterpreterView = Backbone.View.extend({
             this.loop();
         } else {
             this.delay = $("#delay").val();
+        }
+    },
+    updateInputPattern: function () {
+        var $hex = $("#hex-io");
+        if ($hex.is(":checked")) {
+            this.input.attr("pattern", "[0-9a-fA-F]{1,2}").removeAttr("maxlength");
+        } else {
+            this.input.attr("maxlength", "1").removeAttr("pattern");
         }
     }
 });


### PR DESCRIPTION
Thourg most of brainfuck miplementations lack support of byte input and output, this feature could be life-channging for many programmers willing to implement simple arithmetic algorithms without messing around with input tricks.

This pull request adds an option to input data in hex format (but only through the input field), with all the correcponding validation checks for input field and descriptive user hints.